### PR TITLE
Release 3.1.0 (#11)

### DIFF
--- a/BuildAPIAccess.h
+++ b/BuildAPIAccess.h
@@ -21,7 +21,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 //
-//  BuildAPIAccess 3.0.1
+
+//  BuildAPIAccess 3.1.0
 
 
 #import <Foundation/Foundation.h>
@@ -37,13 +38,13 @@
     NSURLSession *apiSession;
 
     NSMutableArray *connexions, *pendingConnections, *loggingDevices, *products, *devices;
-    NSMutableArray *devicegroups, *deployments, *history, *logs;
+    NSMutableArray *devicegroups, *deployments, *history, *logs, *logConnexions;
 
     NSDictionary *me;
 
     NSOperationQueue *eventQueue;
 
-    NSString *baseURL, *userAgent, *username, *password, *logStreamID, *deviceToStream;
+    NSString *baseURL, *userAgent, *username, *password, *logStreamID;
 
     NSDateFormatter *dateFormatter;
 
@@ -55,7 +56,7 @@
 
     BOOL pageSizeChangeFlag, logIsClosed, restartingLog, useTwoFactor;
 
-    id logLastEventID;
+    id logLastEventID, savedObject;
 
     Connexion *logConnexion, *tokenConnexion;
 
@@ -68,7 +69,7 @@
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 
 // Login Methods
-- (void)login:(NSString *)userName :(NSString *)passWord :(NSUInteger)cloudCode :(BOOL)is2FA;
+- (void)login:(NSString *)userName :(NSString *)passWord :(NSUInteger)cloudCode;
 - (void)getNewAccessToken;
 - (void)refreshAccessToken:(NSString *)loginKey;
 - (BOOL)isAccessTokenValid;
@@ -181,7 +182,7 @@
 - (void)stopLogging:(NSString *)deviceID;
 - (void)stopLogging:(NSString *)deviceID :(id)someObject;
 - (void)restartLogging;
-- (void)startStream:(NSURL *)url;
+- (void)startStream;
 - (void)openStream;
 - (void)closeStream;
 - (void)dispatchEvent:(LogStreamEvent *)event;

--- a/BuildAPIAccessConstants.h
+++ b/BuildAPIAccessConstants.h
@@ -21,7 +21,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 //
-//  BuildAPIAccess 3.0.1
+
+//  BuildAPIAccess 3.1.0
 
 
 #ifndef BuildAPIContants_h
@@ -29,7 +30,8 @@
 
 // Build API Access Version
 
-#define kBuildAPIAccessVersion                  @"3.0.1"
+
+#define kBuildAPIAccessVersion                  @"3.1.0"
 
 // Connection Types / Actions
 
@@ -76,11 +78,11 @@
 #define kConnectTypeGetAccessToken              80
 #define kConnectTypeRefreshAccessToken          81
 #define kConnectTypeGetMyAccount                82
-#define kConnectTypeGetLogStreamID              83
-#define kConnectTypeStreamActive                84
-#define kConnectTypeAddLogStream                85
-#define kConnectTypeEndLogStream                86
-#define kConnectTypeGetAnAccount                87
+#define kConnectTypeGetAnAccount                83
+#define kConnectTypeLogGetStreamID              84
+#define kConnectTypeLogStreamActive             85
+#define kConnectTypeLogStreamAdd                86
+#define kConnectTypeLogStreamEnd                87
 
 #define kConnectTypeGetLoginToken               90
 
@@ -99,6 +101,7 @@
 #define kMaxHistoricalLogs                      1000
 #define kLogTimeout                             300.0
 #define klogRetryInterval                       10.0
+#define kLogMaxDevicesPerLog                    8
 
 // Pagination
 
@@ -114,6 +117,8 @@
 #define kErrorLoginNoPassword                   12
 #define kErrorLoginNoCredentials                13
 #define kErrorLoginRejectCredentials            14
+
+#define kConnectTimeoutInterval                 120
 
 
 #endif

--- a/Connexion.h
+++ b/Connexion.h
@@ -21,7 +21,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 //
-//  BuildAPIAccess 3.0.1
+
+//  BuildAPIAccess 3.1.0
 
 
 #import <Foundation/Foundation.h>

--- a/Connexion.m
+++ b/Connexion.m
@@ -21,7 +21,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 //
-//  BuildAPIAccess 3.0.1
+
+//  BuildAPIAccess 3.1.0
 
 
 #import "Connexion.h"

--- a/LogStreamEvent.h
+++ b/LogStreamEvent.h
@@ -21,7 +21,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 //
-//  BuildAPIAccess 3.0.1
+
+//  BuildAPIAccess 3.1.0
 
 
 #import <Foundation/Foundation.h>

--- a/LogStreamEvent.m
+++ b/LogStreamEvent.m
@@ -21,7 +21,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 //
-//  BuildAPIAccess 3.0.1
+
+//  BuildAPIAccess 3.1.0
 
 
 #import "LogStreamEvent.h"

--- a/Token.h
+++ b/Token.h
@@ -21,7 +21,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 //
-//  BuildAPIAccess 3.0.1
+
+//  BuildAPIAccess 3.1.0
 
 
 #import <Foundation/Foundation.h>

--- a/Token.m
+++ b/Token.m
@@ -21,7 +21,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 //
-//  BuildAPIAccess 3.0.1
+
+//  BuildAPIAccess 3.1.0
 
 
 #import "Token.h"


### PR DESCRIPTION
* Clear impCloud code on logout
* Add extended 'getMyAccount:' method, fix code triggered in response
* Add 'getAnAccount:' method
* Stop auto-requesting user's account details
* Attempt to stop response cacheing
* Workaround issue preventing changes to device groups from being rejected by the server
* Prelim work on OTP support
* Add, rename constants
* Remove properties, update method prototypes
* Refactor logging code
* Fix 2FA
* Issue a notification on error; add code to all general errs
* Add separate Notifications section
* Remove is2FA parameter from login:

* Bump to 3.1.0

* Update for 3.1.0

* Add release date